### PR TITLE
ftxui: reset urls to original repo

### DIFF
--- a/packages/f/ftxui/xmake.lua
+++ b/packages/f/ftxui/xmake.lua
@@ -3,8 +3,14 @@ package("ftxui")
     set_description(":computer: C++ Functional Terminal User Interface. :heart:")
     set_license("MIT")
 
-    add_urls("https://github.com/mikomikotaishi/FTXUI/archive/refs/tags/$(version).tar.gz",
-             "https://github.com/mikomikotaishi/FTXUI.git")
+    add_urls("https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/ArthurSonzogni/FTXUI.git")
+    add_versions("v6.1.9", "45819c1e54914783d4a1ca5633885035d74146778a1f74e1213cdb7b76340e71")
+    add_versions("v6.1.1", "eb3546cc662c18f0c3f54ece72618fe43905531d2088e4ba8081983fa8986b95")
+    add_versions("v6.0.2", "ace3477a8dd7cdb911dbc75e7b43cdcc9cf1d4a3cc3fb41168ecc31c06626cb9")
+    add_versions("v5.0.0", "a2991cb222c944aee14397965d9f6b050245da849d8c5da7c72d112de2786b5b")
+    add_versions("v4.1.1", "9009d093e48b3189487d67fc3e375a57c7b354c0e43fc554ad31bec74a4bc2dd")
+    add_versions("v3.0.0", "a8f2539ab95caafb21b0c534e8dfb0aeea4e658688797bb9e5539729d9258cc1")
 
     add_deps("cmake")
 


### PR DESCRIPTION
The previously linked fork adding support for module was merged and deleted, reset package urls to original repository